### PR TITLE
Add various new functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dist/
+.cabal-sandbox/
+cabal.sandbox.config
+

--- a/posix-paths.cabal
+++ b/posix-paths.cabal
@@ -27,7 +27,9 @@ Library
                         System.Posix.FilePath
     build-depends:      base >= 4.2 && < 4.10,
                         bytestring >= 0.9.2.0 && < 0.12,
-                        unix >= 2.5 && < 2.8
+                        unix >= 2.5 && < 2.8,
+                        word8
+
 
 test-suite doctests
     default-language:   Haskell2010

--- a/posix-paths.cabal
+++ b/posix-paths.cabal
@@ -57,9 +57,9 @@ benchmark bench.hs
       bytestring,
       unix,
       directory  >= 1.1 && < 1.3,
-      filepath   >= 1.2 && < 1.4,
+      filepath   >= 1.2 && < 1.5,
       process    >= 1.0 && < 1.3,
-      criterion  >= 0.6 && < 0.9
+      criterion  >= 0.6 && < 1.2
   ghc-options: -O2
 
 source-repository head

--- a/posix-paths.cabal
+++ b/posix-paths.cabal
@@ -24,7 +24,8 @@ Library
     c-sources:          cbits/dirutils.c
     exposed-modules:    System.Posix.Directory.Foreign,
                         System.Posix.Directory.Traversals,
-                        System.Posix.FilePath
+                        System.Posix.FilePath,
+                        System.Posix.FD
     build-depends:      base >= 4.2 && < 4.10,
                         bytestring >= 0.9.2.0 && < 0.12,
                         unix >= 2.5 && < 2.8,

--- a/src/System/Posix/Directory/Foreign.hsc
+++ b/src/System/Posix/Directory/Foreign.hsc
@@ -38,13 +38,15 @@ oCloexec = Flags #{const O_CLOEXEC}
 oCloexec = UnsupportedFlag "O_CLOEXEC"
 #endif
 
+
+
 -- If these enum declarations occur earlier in the file, haddock
 -- gets royally confused about the above doc comments.
 -- Probably http://trac.haskell.org/haddock/ticket/138
 
 #{enum DirType, DirType, DT_BLK, DT_CHR, DT_DIR, DT_FIFO, DT_LNK, DT_REG, DT_SOCK, DT_UNKNOWN}
 
-#{enum Flags, Flags, O_APPEND, O_ASYNC, O_CREAT, O_DIRECTORY, O_EXCL, O_NOCTTY, O_NOFOLLOW, O_NONBLOCK, O_RDONLY, O_SYNC, O_TRUNC}
+#{enum Flags, Flags, O_APPEND, O_ASYNC, O_CREAT, O_DIRECTORY, O_EXCL, O_NOCTTY, O_NOFOLLOW, O_NONBLOCK, O_RDONLY, O_WRONLY, O_RDWR, O_SYNC, O_TRUNC}
 
 pathMax :: Int
 pathMax = #{const PATH_MAX}

--- a/src/System/Posix/Directory/Traversals.hs
+++ b/src/System/Posix/Directory/Traversals.hs
@@ -49,6 +49,8 @@ import Foreign.Storable
 -- Upon entering a directory, 'allDirectoryContents' will get all entries
 -- strictly.  However the returned list is lazy in that directories will only
 -- be accessed on demand.
+--
+-- Follows symbolic links for the input dir.
 allDirectoryContents :: RawFilePath -> IO [RawFilePath]
 allDirectoryContents topdir = do
     namesAndTypes <- getDirectoryContents topdir
@@ -66,6 +68,8 @@ allDirectoryContents topdir = do
     return (topdir : concat paths)
 
 -- | Get all files from a directory and its subdirectories strictly.
+--
+-- Follows symbolic links for the input dir.
 allDirectoryContents' :: RawFilePath -> IO [RawFilePath]
 allDirectoryContents' = fmap reverse . traverseDirectory (\acc fp -> return (fp:acc)) []
 -- this uses traverseDirectory because it's more efficient than forcing the
@@ -75,6 +79,8 @@ allDirectoryContents' = fmap reverse . traverseDirectory (\acc fp -> return (fp:
 -- files/subdirectories.
 --
 -- This function allows for memory-efficient traversals.
+--
+-- Follows symbolic links for the input dir.
 traverseDirectory :: (s -> RawFilePath -> IO s) -> s -> RawFilePath -> IO s
 traverseDirectory act s0 topdir = toploop
   where
@@ -176,6 +182,7 @@ readDirEnt (unpackDirStream -> dirp) =
                     then return (dtUnknown,BS.empty)
                     else throwErrno "readDirEnt"
 
+-- |Gets all directory contents (not recursively).
 getDirectoryContents :: RawFilePath -> IO [(DirType, RawFilePath)]
 getDirectoryContents path =
   modifyIOError ((`ioeSetFileName` (BS.unpack path)) .
@@ -193,7 +200,7 @@ getDirectoryContents path =
 
 -- | return the canonicalized absolute pathname
 --
--- like canonicalizePath, but uses realpath(3)
+-- like canonicalizePath, but uses @realpath(3)@
 realpath :: RawFilePath -> IO RawFilePath
 realpath inp = do
     allocaBytes pathMax $ \tmp -> do

--- a/src/System/Posix/Directory/Traversals.hs
+++ b/src/System/Posix/Directory/Traversals.hs
@@ -7,6 +7,7 @@
 module System.Posix.Directory.Traversals (
 
   getDirectoryContents
+, getDirectoryContents'
 
 , allDirectoryContents
 , allDirectoryContents'
@@ -16,6 +17,7 @@ module System.Posix.Directory.Traversals (
 , readDirEnt
 , packDirStream
 , unpackDirStream
+, fdOpendir
 
 , realpath
 ) where
@@ -34,6 +36,7 @@ import System.Posix.Directory.ByteString as PosixBS
 import System.Posix.Files.ByteString
 
 import System.IO.Unsafe
+import System.Posix.IO.ByteString (closeFd)
 import Unsafe.Coerce (unsafeCoerce)
 import Foreign.C.Error
 import Foreign.C.String
@@ -41,6 +44,9 @@ import Foreign.C.Types
 import Foreign.Marshal.Alloc (alloca,allocaBytes)
 import Foreign.Ptr
 import Foreign.Storable
+
+
+
 
 ----------------------------------------------------------
 
@@ -152,8 +158,12 @@ foreign import ccall unsafe "__posixdir_d_type"
 foreign import ccall "realpath"
   c_realpath :: CString -> CString -> IO CString
 
+foreign import ccall unsafe "fdopendir"
+  c_fdopendir :: Posix.Fd -> IO (Ptr ())
+
 ----------------------------------------------------------
 -- less dodgy but still lower-level
+
 
 readDirEnt :: DirStream -> IO (DirType, RawFilePath)
 readDirEnt (unpackDirStream -> dirp) =
@@ -182,6 +192,7 @@ readDirEnt (unpackDirStream -> dirp) =
                     then return (dtUnknown,BS.empty)
                     else throwErrno "readDirEnt"
 
+
 -- |Gets all directory contents (not recursively).
 getDirectoryContents :: RawFilePath -> IO [(DirType, RawFilePath)]
 getDirectoryContents path =
@@ -190,13 +201,39 @@ getDirectoryContents path =
     bracket
       (PosixBS.openDirStream path)
       PosixBS.closeDirStream
-      loop
- where
-  loop dirp = do
-     t@(_typ,e) <- readDirEnt dirp
-     if BS.null e then return [] else do
-       es <- loop dirp
-       return (t:es)
+      _dirloop
+
+
+-- |Binding to @fdopendir(3)@.
+fdOpendir :: Posix.Fd -> IO DirStream
+fdOpendir fd =
+    packDirStream <$> throwErrnoIfNull "fdOpendir" (c_fdopendir fd)
+
+
+-- |Like `getDirectoryContents` except for a file descriptor.
+--
+-- To avoid complicated error checks, the file descriptor is
+-- __always__ closed, even if `fdOpendir` fails. Usually, this
+-- only happens on successful `fdOpendir` and after the directory
+-- stream is closed. Also see the manpage of @fdopendir(3)@ for
+-- more details.
+getDirectoryContents' :: Posix.Fd -> IO [(DirType, RawFilePath)]
+getDirectoryContents' fd = do
+  dirstream <- fdOpendir fd `catchIOError` \e -> do
+    closeFd fd
+    ioError e
+  -- closeDirStream closes the filedescriptor
+  finally (_dirloop dirstream) (PosixBS.closeDirStream dirstream)
+
+
+_dirloop :: DirStream -> IO [(DirType, RawFilePath)]
+{-# INLINE _dirloop #-}
+_dirloop dirp = do
+   t@(_typ,e) <- readDirEnt dirp
+   if BS.null e then return [] else do
+     es <- _dirloop dirp
+     return (t:es)
+
 
 -- | return the canonicalized absolute pathname
 --

--- a/src/System/Posix/Directory/Traversals.hs
+++ b/src/System/Posix/Directory/Traversals.hs
@@ -110,17 +110,17 @@ actOnDirContents :: RawFilePath
                  -> IO b
 actOnDirContents pathRelToTop b f =
   modifyIOError ((`ioeSetFileName` (BS.unpack pathRelToTop)) .
-                 (`ioeSetLocation` "findBSTypRel")) $ do
+                 (`ioeSetLocation` "findBSTypRel")) $
     bracket
       (openDirStream pathRelToTop)
-      (Posix.closeDirStream)
+      Posix.closeDirStream
       (\dirp -> loop dirp b)
  where
   loop dirp b' = do
     (typ,e) <- readDirEnt dirp
     if (e == "")
       then return b'
-      else do
+      else
           if (e == "." || e == "..")
               then loop dirp b'
               else f typ (pathRelToTop </> e) b' >>= loop dirp
@@ -197,7 +197,7 @@ readDirEnt (unpackDirStream -> dirp) =
 getDirectoryContents :: RawFilePath -> IO [(DirType, RawFilePath)]
 getDirectoryContents path =
   modifyIOError ((`ioeSetFileName` (BS.unpack path)) .
-                 (`ioeSetLocation` "System.Posix.Directory.Traversals.getDirectoryContents")) $ do
+                 (`ioeSetLocation` "System.Posix.Directory.Traversals.getDirectoryContents")) $
     bracket
       (PosixBS.openDirStream path)
       PosixBS.closeDirStream
@@ -239,7 +239,7 @@ _dirloop dirp = do
 --
 -- like canonicalizePath, but uses @realpath(3)@
 realpath :: RawFilePath -> IO RawFilePath
-realpath inp = do
+realpath inp =
     allocaBytes pathMax $ \tmp -> do
         void $ BS.useAsCString inp $ \cstr -> throwErrnoIfNull "realpath" $ c_realpath cstr tmp
         BS.packCString tmp

--- a/src/System/Posix/FD.hs
+++ b/src/System/Posix/FD.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+{-# OPTIONS_GHC -Wall #-}
+
+-- |Provides an alternative for `System.Posix.IO.ByteString.openFd`
+-- which gives us more control on what status flags to pass to the
+-- low-level `open(2)` call, in contrast to the unix package.
+module System.Posix.FD (
+  openFd
+) where
+
+
+import Foreign.C.String
+import Foreign.C.Types
+import System.Posix.Directory.Foreign
+import qualified System.Posix as Posix
+import System.Posix.ByteString.FilePath
+
+
+foreign import ccall unsafe "open"
+   c_open :: CString -> CInt -> Posix.CMode -> IO CInt
+
+
+open_  :: CString
+       -> Posix.OpenMode
+       -> [Flags]
+       -> Maybe Posix.FileMode
+       -> IO Posix.Fd
+open_ str how optional_flags maybe_mode = do
+    fd <- c_open str all_flags mode_w
+    return (Posix.Fd fd)
+  where
+    all_flags  = unionFlags $ optional_flags ++ [open_mode] ++ creat
+
+
+    (creat, mode_w) = case maybe_mode of
+                        Nothing -> ([],0)
+                        Just x  -> ([oCreat], x)
+
+    open_mode = case how of
+                   Posix.ReadOnly  -> oRdonly
+                   Posix.WriteOnly -> oWronly
+                   Posix.ReadWrite -> oRdwr
+
+
+-- |Open and optionally create this file. See 'System.Posix.Files'
+-- for information on how to use the 'FileMode' type.
+--
+-- Note that passing `Just x` as the 4th argument triggers the
+-- `oCreat` status flag, which must be set when you pass in `oExcl`
+-- to the status flags. Also see the manpage for `open(2)`.
+openFd :: RawFilePath
+       -> Posix.OpenMode
+       -> [Flags]               -- ^ status flags of open(2)
+       -> Maybe Posix.FileMode  -- ^ Just x => creates the file with the given modes, Nothing => the file must exist.
+       -> IO Posix.Fd
+openFd name how optional_flags maybe_mode =
+   withFilePath name $ \str ->
+     throwErrnoPathIfMinus1Retry "openFd" name $
+       open_ str how optional_flags maybe_mode
+

--- a/src/System/Posix/FilePath.hs
+++ b/src/System/Posix/FilePath.hs
@@ -45,6 +45,7 @@ module System.Posix.FilePath (
 
 , isRelative
 , isAbsolute
+, isValid
 
 , module System.Posix.ByteString.FilePath
 ) where
@@ -435,6 +436,20 @@ isAbsolute x
 -- prop> \path -> isRelative path /= isAbsolute path
 isRelative :: RawFilePath -> Bool
 isRelative = not . isAbsolute
+
+-- | Is a FilePath valid, i.e. could you create a file like it?
+--
+-- >>> isValid ""
+-- False
+-- >>> isValid "\0"
+-- False
+-- >>> isValid "/random_ path:*"
+-- True
+isValid :: RawFilePath -> Bool
+isValid filepath
+  | BS.null filepath        = False
+  | _nul `BS.elem` filepath = False
+  | otherwise               = True
 
 ------------------------
 -- internal stuff

--- a/src/System/Posix/FilePath.hs
+++ b/src/System/Posix/FilePath.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_GHC -Wall #-}
 

--- a/src/System/Posix/FilePath.hs
+++ b/src/System/Posix/FilePath.hs
@@ -56,6 +56,7 @@ module System.Posix.FilePath (
 , isRelative
 , isAbsolute
 , isValid
+, isFileName
 , equalFilePath
 
 , module System.Posix.ByteString.FilePath
@@ -502,6 +503,27 @@ isValid filepath
   | BS.null filepath        = False
   | _nul `BS.elem` filepath = False
   | otherwise               = True
+
+-- | Is the given path a valid filename? This includes
+-- "." and "..".
+--
+-- >>> isFileName "lal"
+-- True
+-- >>> isFileName "."
+-- True
+-- >>> isFileName ".."
+-- True
+-- >>> isFileName ""
+-- False
+-- >>> isFileName "\0"
+-- False
+-- >>> isFileName "/random_ path:*"
+-- False
+isFileName :: RawFilePath -> Bool
+isFileName filepath =
+  not (BS.singleton pathSeparator `BS.isInfixOf` filepath) &&
+  not (BS.null filepath) &&
+  not (_nul `BS.elem` filepath)
 
 -- |Equality of two filepaths. The filepaths are normalised
 -- and trailing path separators are dropped.

--- a/src/System/Posix/FilePath.hs
+++ b/src/System/Posix/FilePath.hs
@@ -7,6 +7,7 @@
 -- Not all functions of "System.FilePath" are implemented yet. Feel free to contribute!
 module System.Posix.FilePath (
 
+  -- * Separators
   pathSeparator
 , isPathSeparator
 , searchPathSeparator
@@ -14,6 +15,7 @@ module System.Posix.FilePath (
 , extSeparator
 , isExtSeparator
 
+  -- * File extensions
 , splitExtension
 , takeExtension
 , replaceExtension
@@ -25,6 +27,7 @@ module System.Posix.FilePath (
 , dropExtensions
 , takeExtensions
 
+  -- * Filenames/Directory names
 , splitFileName
 , takeFileName
 , replaceFileName
@@ -33,17 +36,23 @@ module System.Posix.FilePath (
 , replaceBaseName
 , takeDirectory
 , replaceDirectory
+
+  -- * Path combinators and splitters
 , combine
 , (</>)
 , splitPath
 , joinPath
-, normalise
 , splitDirectories
 
+  -- * Path conversions
+, normalise
+
+  -- * Trailing path separator
 , hasTrailingPathSeparator
 , addTrailingPathSeparator
 , dropTrailingPathSeparator
 
+  -- * Queries
 , isRelative
 , isAbsolute
 , isValid
@@ -109,10 +118,8 @@ isExtSeparator = (== extSeparator)
 --
 -- >>> splitExtension "file.exe"
 -- ("file",".exe")
---
 -- >>> splitExtension "file"
 -- ("file","")
---
 -- >>> splitExtension "/path/file.tar.gz"
 -- ("/path/file.tar",".gz")
 --
@@ -129,10 +136,8 @@ splitExtension x = if BS.null basename
 --
 -- >>> takeExtension "file.exe"
 -- ".exe"
---
 -- >>> takeExtension "file"
 -- ""
---
 -- >>> takeExtension "/path/file.tar.gz"
 -- ".gz"
 takeExtension :: RawFilePath -> ByteString
@@ -148,10 +153,8 @@ replaceExtension path ext = dropExtension path <.> ext
 --
 -- >>> dropExtension "file.exe"
 -- "file"
---
 -- >>> dropExtension "file"
 -- "file"
---
 -- >>> dropExtension "/path/file.tar.gz"
 -- "/path/file.tar"
 dropExtension :: RawFilePath -> RawFilePath
@@ -161,10 +164,8 @@ dropExtension = fst . splitExtension
 --
 -- >>> addExtension "file" ".exe"
 -- "file.exe"
---
 -- >>> addExtension "file.tar" ".gz"
 -- "file.tar.gz"
---
 -- >>> addExtension "/path/" ".ext"
 -- "/path/.ext"
 addExtension :: RawFilePath -> ByteString -> RawFilePath
@@ -182,10 +183,8 @@ addExtension file ext
 --
 -- >>> hasExtension "file"
 -- False
---
 -- >>> hasExtension "file.tar"
 -- True
---
 -- >>> hasExtension "/path.part1/"
 -- False
 hasExtension :: RawFilePath -> Bool
@@ -226,10 +225,8 @@ takeExtensions = snd . splitExtensions
 --
 -- >>> splitFileName "path/file.txt"
 -- ("path/","file.txt")
---
 -- >>> splitFileName "path/"
 -- ("path/","")
---
 -- >>> splitFileName "file.txt"
 -- ("./","file.txt")
 --
@@ -247,7 +244,6 @@ splitFileName x = if BS.null path
 --
 -- >>> takeFileName "path/file.txt"
 -- "file.txt"
---
 -- >>> takeFileName "path/"
 -- ""
 takeFileName :: RawFilePath -> RawFilePath
@@ -263,7 +259,6 @@ replaceFileName x y = fst (splitFileNameRaw x) </> y
 --
 -- >>> dropFileName "path/file.txt"
 -- "path/"
---
 -- >>> dropFileName "file.txt"
 -- "./"
 dropFileName :: RawFilePath -> RawFilePath
@@ -273,7 +268,6 @@ dropFileName = fst . splitFileName
 --
 -- >>> takeBaseName "path/file.tar.gz"
 -- "file.tar"
---
 -- >>> takeBaseName ""
 -- ""
 takeBaseName :: RawFilePath -> ByteString
@@ -295,13 +289,10 @@ replaceBaseName path name = combineRaw dir (name <.> ext)
 --
 -- >>> takeDirectory "path/file.txt"
 -- "path"
---
 -- >>> takeDirectory "file"
 -- "."
---
 -- >>> takeDirectory "/path/to/"
 -- "/path/to"
---
 -- >>> takeDirectory "/path/to"
 -- "/path"
 takeDirectory :: RawFilePath -> RawFilePath
@@ -450,7 +441,6 @@ hasTrailingPathSeparator x
 --
 -- >>> addTrailingPathSeparator "/path"
 -- "/path/"
---
 -- >>> addTrailingPathSeparator "/path/"
 -- "/path/"
 -- >>> addTrailingPathSeparator "/"
@@ -466,7 +456,6 @@ addTrailingPathSeparator x = if hasTrailingPathSeparator x
 -- "/path"
 -- >>> dropTrailingPathSeparator "/path////"
 -- "/path"
---
 -- >>> dropTrailingPathSeparator "/"
 -- "/"
 -- >>> dropTrailingPathSeparator "//"

--- a/src/System/Posix/FilePath.hs
+++ b/src/System/Posix/FilePath.hs
@@ -59,6 +59,7 @@ module System.Posix.FilePath (
 , isFileName
 , hasParentDir
 , equalFilePath
+, hiddenFile
 
 , module System.Posix.ByteString.FilePath
 ) where
@@ -578,6 +579,34 @@ equalFilePath :: RawFilePath -> RawFilePath -> Bool
 equalFilePath p1 p2 = f p1 == f p2
   where
     f x = dropTrailingPathSeparator $ normalise x
+
+
+-- | Whether the file is a hidden file.
+--
+-- >>> hiddenFile ".foo"
+-- True
+-- >>> hiddenFile "..foo.bar"
+-- True
+-- >>> hiddenFile "some/path/.bar"
+-- True
+-- >>> hiddenFile "..."
+-- True
+-- >>> hiddenFile "dod.bar"
+-- False
+-- >>> hiddenFile "."
+-- False
+-- >>> hiddenFile ".."
+-- False
+-- >>> hiddenFile ""
+-- False
+hiddenFile :: RawFilePath -> Bool
+hiddenFile fp
+  | fn == BS.pack [_period, _period] = False
+  | fn == BS.pack [_period]          = False
+  | otherwise                        = BS.pack [extSeparator]
+                                         `BS.isPrefixOf` fn
+  where
+    fn = takeFileName fp
 
 ------------------------
 -- internal stuff

--- a/src/System/Posix/FilePath.hs
+++ b/src/System/Posix/FilePath.hs
@@ -57,6 +57,7 @@ module System.Posix.FilePath (
 , isAbsolute
 , isValid
 , isFileName
+, hasParentDir
 , equalFilePath
 
 , module System.Posix.ByteString.FilePath
@@ -524,6 +525,37 @@ isFileName filepath =
   not (BS.singleton pathSeparator `BS.isInfixOf` filepath) &&
   not (BS.null filepath) &&
   not (_nul `BS.elem` filepath)
+
+-- | Check if the filepath has any parent directories in it.
+--
+-- >>> hasParentDir "/.."
+-- True
+-- >>> hasParentDir "foo/bar/.."
+-- True
+-- >>> hasParentDir "foo/../bar/."
+-- True
+-- >>> hasParentDir "foo/bar"
+-- False
+-- >>> hasParentDir "foo"
+-- False
+-- >>> hasParentDir ""
+-- False
+-- >>> hasParentDir ".."
+-- False
+hasParentDir :: RawFilePath -> Bool
+hasParentDir filepath =
+    (pathSeparator `BS.cons` pathDoubleDot)
+     `BS.isSuffixOf` filepath
+   ||
+    (BS.singleton pathSeparator
+        `BS.append` pathDoubleDot
+        `BS.append` BS.singleton pathSeparator)
+     `BS.isInfixOf`  filepath
+   ||
+    (pathDoubleDot `BS.append` BS.singleton pathSeparator)
+      `BS.isPrefixOf` filepath
+  where
+    pathDoubleDot = BS.pack [_period, _period]
 
 -- |Equality of two filepaths. The filepaths are normalised
 -- and trailing path separators are dropped.


### PR DESCRIPTION
things to clear up:
* is the module name `System.Posix.FD` fine for the alternative `openFd` version?
* can someone check that the benchmarks did not go down because of 1ce76319fec7561db63124f1e11c093072c3d848 ...although I forced the inline pragma on `_dirloop`
* not 100% sure if this requires a major version bump for another release... apart from changing the behavior of `hasTrailingPathSeparator` and `dropTrailingPathSeparator` stuff was only added