### PR TITLE
Use https for source repo url

### DIFF
--- a/posix-paths.cabal
+++ b/posix-paths.cabal
@@ -62,4 +62,4 @@ benchmark bench.hs
 
 source-repository head
   type:                git
-  location:            git://github.com/JohnLato/posix-paths.git
+  location:            https://github.com/JohnLato/posix-paths.git


### PR DESCRIPTION
GitHub no longer supports the git:// protocol.